### PR TITLE
Fix timestamp formatting and improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,14 @@ B)202506171400 C)202506181400
 D)ALL NOTAMS REQUESTED
 E)Additional remarks if any
 )
+```
+
+## Usage
+
+To run the application locally using Docker:
+
+```bash
+docker-compose up --build
+```
+
+Then open [http://localhost:8080](http://localhost:8080) in your browser.

--- a/src/script.js
+++ b/src/script.js
@@ -1,11 +1,13 @@
 // NOTAM Request Generator JavaScript
 
-// Initialize the application
-document.addEventListener('DOMContentLoaded', function() {
-    setDefaultTimes();
-    setupEventListeners();
-    loadSavedData();
-});
+// Initialize the application (only when running in a browser)
+if (typeof document !== 'undefined') {
+    document.addEventListener('DOMContentLoaded', function() {
+        setDefaultTimes();
+        setupEventListeners();
+        loadSavedData();
+    });
+}
 
 // Set current date/time as default
 function setDefaultTimes() {
@@ -58,7 +60,12 @@ function debounce(func, wait) {
 function formatDateTime(dateTimeStr) {
     if (!dateTimeStr) return '';
     const date = new Date(dateTimeStr);
-    return date.toISOString().replace(/[-:]/g, '').slice(0, 12);
+    const year = date.getUTCFullYear().toString().padStart(4, '0');
+    const month = String(date.getUTCMonth() + 1).padStart(2, '0');
+    const day = String(date.getUTCDate()).padStart(2, '0');
+    const hours = String(date.getUTCHours()).padStart(2, '0');
+    const minutes = String(date.getUTCMinutes()).padStart(2, '0');
+    return `${year}${month}${day}${hours}${minutes}`;
 }
 
 // Generate AFTN message
@@ -146,7 +153,7 @@ function validateForm(data) {
 function buildAFTNMessage(data) {
     // Generate timestamp
     const now = new Date();
-    const timestamp = now.toISOString().replace(/[-:]/g, '').slice(0, 12);
+    const timestamp = formatDateTime(now.toISOString());
     
     // Generate message number (using timestamp for uniqueness)
     const msgNumber = timestamp.slice(-4);


### PR DESCRIPTION
## Summary
- avoid DOM errors when requiring script in Node
- correct UTC timestamp formatting
- document Docker usage in the readme

## Testing
- `node --check src/script.js`
- `docker-compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850fb14fe2c832ab7aec67f5feec431