### PR TITLE
Store default settings globally

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ A web application for generating AFTN-formatted NOTAM (Notice to Airmen) request
 - **Data Persistence**: Automatically saves form data locally
 - **Responsive Design**: Works on desktop, tablet, and mobile devices
 - **Docker Ready**: Complete containerization for easy deployment
-- **Admin Panel**: Configure default values for all fields at `/admin`
+- **Admin Panel**: Configure default values for all fields at `/admin`. These
+  settings are stored as global defaults and loaded whenever the form is opened.
 
 ## AFTN Message Format
 

--- a/src/admin/admin.js
+++ b/src/admin/admin.js
@@ -6,6 +6,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
 function loadAdminDefaults() {
     const defaults = getStoredDefaults();
+    // Expose defaults globally so other pages can access them
+    if (typeof globalThis !== 'undefined') {
+        globalThis.notamGlobalDefaults = defaults;
+    }
     Object.keys(defaults).forEach(key => {
         const el = document.getElementById(key);
         if (el && defaults[key]) {
@@ -17,11 +21,17 @@ function loadAdminDefaults() {
 function saveDefaults() {
     const data = collectFormData();
     localStorage.setItem('notamDefaultSettings', JSON.stringify(data));
+    if (typeof globalThis !== 'undefined') {
+        globalThis.notamGlobalDefaults = data;
+    }
     showNotification('Defaults saved successfully!', 'success');
 }
 
 function clearDefaults() {
     localStorage.removeItem('notamDefaultSettings');
+    if (typeof globalThis !== 'undefined') {
+        globalThis.notamGlobalDefaults = {};
+    }
     const elements = document.querySelectorAll('input, select, textarea');
     elements.forEach(el => {
         if (el.type === 'select-one') {

--- a/src/script.js
+++ b/src/script.js
@@ -301,22 +301,30 @@ function saveFormData() {
 
 // Load admin-defined default settings
 function loadDefaultSettings() {
-    if (typeof(Storage) !== "undefined") {
+    let data = {};
+
+    if (typeof globalThis !== 'undefined' && globalThis.notamGlobalDefaults) {
+        data = globalThis.notamGlobalDefaults;
+    } else if (typeof(Storage) !== "undefined") {
         const defaults = localStorage.getItem('notamDefaultSettings');
         if (defaults) {
             try {
-                const data = JSON.parse(defaults);
-                Object.keys(data).forEach(key => {
-                    const element = document.getElementById(key);
-                    if (element && data[key]) {
-                        element.value = data[key];
-                    }
-                });
+                data = JSON.parse(defaults);
+                if (typeof globalThis !== 'undefined') {
+                    globalThis.notamGlobalDefaults = data;
+                }
             } catch (error) {
                 console.error('Error loading default settings:', error);
             }
         }
     }
+
+    Object.keys(data).forEach(key => {
+        const element = document.getElementById(key);
+        if (element && data[key]) {
+            element.value = data[key];
+        }
+    });
 }
 
 // Load saved form data


### PR DESCRIPTION
## Summary
- set admin defaults on `globalThis`
- load global default settings in the main script
- document global default behaviour in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68523935fd84832a8a3fb43711d7c9c9